### PR TITLE
Document relationship between deterministic and zone matching plans

### DIFF
--- a/docs/deterministic_matching_plan.md
+++ b/docs/deterministic_matching_plan.md
@@ -1,5 +1,10 @@
 # Deterministic Matching Plan for Campus-Only Rideshare
 
+## How this plan relates to other approaches
+- Serves as the launch-day workflow for the UNM-Taos pilot when rider and driver volumes are small enough that per-trip routing checks remain affordable.
+- Establishes the safety, authentication, and detour validation foundations that later approaches (such as the [Zone-Based Matching Plan](zone_based_matching_plan.md)) rely on.
+- Remains relevant even after adopting zones because the same deterministic detour calculation is used during final confirmation in the zone-first workflow.
+
 ## Goals
 - Limit access to University of New Mexico-Taos participants via NetID/SSO login.
 - Enable safe, privacy-preserving carpools that respect 20-minute arrival windows and 3–5 minute detour ceilings.

--- a/docs/zone_based_matching_plan.md
+++ b/docs/zone_based_matching_plan.md
@@ -1,5 +1,17 @@
 # Zone-Based Matching Plan for UNM-Taos Rideshare
 
+## How this plan relates to other approaches
+- Builds on the [Deterministic Matching Plan](deterministic_matching_plan.md) by reusing its authentication, safety, and detour-validation guardrails while moving the initial filtering step to pre-defined zones.
+- Complements (rather than replaces) deterministic matching: zone-first workflows surface candidates quickly, then fall back to deterministic routing for confirmation.
+- Supersedes a deterministic-only deployment once request volume grows enough that per-request routing calls become cost-prohibitive or too slow for riders waiting in the queue.
+
+### Adoption progression
+| Stage | Primary approach | When to use | Signals to advance |
+| --- | --- | --- | --- |
+| 1 | Deterministic route-by-route matching | Pilot launch with <50 daily ride requests where manual oversight is still feasible. | Desire to reduce repeated routing calls, need faster shortlisting for riders. |
+| 2 | Zone-first matching with deterministic confirmation | Demand clusters by neighborhood and teams want faster “top candidates” lists without sacrificing detour limits. | Increased API spend, riders waiting >2 minutes for matches, expansion beyond initial commute hours. |
+| 3 | Expanded zones with analytics-driven refinement | Mature program supporting multi-campus trips or carpools beyond Taos corridors. | Need for dynamic zone tuning, appetite for automated insights, exploration of paid prioritization features. |
+
 ## Overview
 This document outlines a hybrid zone-and-route matching model tailored for The University of New Mexico-Taos pilot. The goal is to keep most interactions fast and lightweight while ensuring detours remain reasonable when riders and drivers finalize a match.
 


### PR DESCRIPTION
## Summary
- add a cross-plan context section to the deterministic matching plan and link to the zone-first workflow
- describe how the zone-based plan builds on deterministic matching and outline an adoption progression table for stakeholders

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dd99a836a483208f9fb333cc50fe41